### PR TITLE
Deploy pipeline based on GitHub pages 

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# left empty intentionally
+# will be set by github actions
+# when building with jsdelivr
+PUBLIC_PATH=

--- a/.env
+++ b/.env
@@ -1,4 +1,21 @@
+# This path variables are
 # left empty intentionally
-# will be set by github actions
-# when building with jsdelivr
+# they will be set by github actions
+# when building with jsdelivr/github pages
+
+# Depolyment path prefix,
+# Everything under ~/public/ is copy-pasted
+# Under this directory, alongwith index.html
+# Example:
+# Deployment URL:
+#       https://visualizd.github.io/client/
+# Example value                     ↓
+#                                   client/
 PUBLIC_PATH=
+
+# Asset path prefix,
+# This is meant to be set by deployment CI
+# to be jsdelivr cdn
+# Example value:
+#   https://cdn.jsdelivr.net/gh/Visualizd/client@master/
+ASSET_PATH=

--- a/.env
+++ b/.env
@@ -19,3 +19,11 @@ PUBLIC_PATH=
 # Example value:
 #   https://cdn.jsdelivr.net/gh/Visualizd/client@master/
 ASSET_PATH=
+
+# This variable configs the mode vue.js router
+# is set to be in, set this to history if web server
+# supports SPA (any path matching); set this to hash
+# if the web server doesn't support any path matching
+# Enum value: history | hash
+# See here: https://router.vuejs.org/api/#mode
+ROUTER_MODE=history

--- a/.env
+++ b/.env
@@ -1,28 +1,29 @@
-# This path variables are
+# These path variables are
 # left empty intentionally
 # they will be set by github actions
-# when building with jsdelivr/github pages
+# when building with github pages and jsdelivr
 
 # Depolyment path prefix,
 # Everything under ~/public/ is copy-pasted
-# Under this directory, alongwith index.html
+# to this directory, alongwith index.html
+# but excluding the assest folder
 # Example:
 # Deployment URL:
 #       https://visualizd.github.io/client/
 # Example value                     ↓
-#                                   client/
+#                                  /client/
 PUBLIC_PATH=
 
 # Asset path prefix,
 # This is meant to be set by deployment CI
-# to be jsdelivr cdn
+# to work with jsdelivr cdn
 # Example value:
 #   https://cdn.jsdelivr.net/gh/Visualizd/client@master/
 ASSET_PATH=
 
 # This variable configs the mode vue.js router
 # is set to be in, set this to history if web server
-# supports SPA (any path matching); set this to hash
+# supports SPA ("any" path matching); set this to hash
 # if the web server doesn't support any path matching
 # Enum value: history | hash
 # See here: https://router.vuejs.org/api/#mode

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -56,29 +56,28 @@ jobs:
       
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          ref: $ASSET_BRANCH
       
       - name: Config git
         run: git config user.name "Assest Bot"
-        
-      - name: Switch Branch
-        run: git checkout --orphan $ASSET_BRANCH
       
       - name: Download Assests
         uses: actions/download-artifact@v2
         with:
           name: assets
-          path: ./assets
+          path: .
         
       - name: Display directory structure (for debuging)
         run: ls -R
           
       - name: Add assests to git
-        run: git --work-tree assets add --all
+        run: git add --all
       
       - name: Commit Assests
         run: |
-          git --work-tree assets commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) uwu"
+          git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (uwu)"
           
       - name: Push to Github
         run: git push origin HEAD:${ASSET_BRANCH} --force
-      
+          

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -77,9 +77,38 @@ jobs:
       - name: Commit and push assests if necessary
         run: |
           if [ $(git diff --stat) != '' ]; then
-            git add --all
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (uwu)"
             git push origin HEAD:${ASSET_BRANCH} --force
+          else
+            echo "No need to commit as there's no changes"
+          fi
+
+  deploy-github-page:
+    name: Deploy to github pages branch
+    runs-on: ubuntu-latest
+    needs: [build-production-files, commit-assets]
+    steps:
+      
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      
+      - name: Create orphan github pages branch
+        run: git checkout --orphan gh-pages
+        
+      - name: Download deployment files
+        uses: actions/download-artifact@v2
+        with:
+          name: deployment-file
+          path: ./dep
+        
+      - name: Add files to git
+        run: git --work-tree dep add --all
+        
+      - name: Commit and push deployment if necessary
+        run: |
+          if [ $(git diff --stat) != '' ]; then
+            git commit -m "Compiled deployment for $(git rev-parse --short $GITHUB_SHA) (0w0)"
+            git push origin HEAD:gh-pages --force
           else
             echo "No need to commit as there's no changes"
           fi

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -1,0 +1,34 @@
+name: Deploy github pages
+#on:
+#    push:
+#      branches:
+#        - master
+on: [workflow_dispatch, push]
+
+jobs:
+  gh-pages-deploy:
+    name: Deploy to gh-pages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup assest branch variable
+          - run: "::set-env name=ASSET_BRANCH::deploy-asset"
+
+      - name: Setup Node.js for use with actions
+        uses: actions/setup-node@v1.1.0
+        with:
+          version:  12.x
+
+      - name: Checkout branch
+        uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+
+      - name: Install npm dependency
+        run: npm ci
+
+      - name: Run npm build script (prod, using jsdelivr)
+        run: npm run build:prod
+        env:
+          PUBLIC_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
+
+      # TODO: Copying asset, push to asset branch & github-pages branch

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -14,7 +14,7 @@ env:
   DEPLOY_BRANCH: gh-pages
 
 # Git bot name
-  GIT_BOT_NAME: 0w0 Deploy Bot
+  GIT_BOT_NAME: \"0w0 Deploy Bot\"
 # See: https://github.community/t/github-actions-bot-email-address/17204/5
   GIT_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
-          ref: ${ASSET_BRANCH}
+          ref: deploy-asset
       
       - name: Config git
         run: git config user.name "Assest Bot"

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
-          ref: $ASSET_BRANCH
+          ref: ${ASSET_BRANCH}
       
       - name: Config git
         run: git config user.name "Assest Bot"

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -14,7 +14,7 @@ env:
   DEPLOY_BRANCH: gh-pages
 
 # Git bot name
-  GIT_BOT_NAME: "0w0 Deploy Bot"
+  GIT_BOT_NAME: '"0w0 Deploy Bot"'
 # See: https://github.community/t/github-actions-bot-email-address/17204/5
   GIT_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -26,10 +26,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./node_modules/.cache
-          # anything should help
-          # if it causes trouble,
-          # just increment the trailling number
-          key: build-cache-0 
+          key: build-cache-${{ github.sha }}
+          restore-keys: build-cache-
 
       - name: Run npm build script (prod, using jsdelivr)
         run: npm run build:prod

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -1,5 +1,14 @@
 name: Deploy github pages
-
+env: 
+# necessary for building production code
+# Example: https://cdn.jsdelivr.net/gh/visualizd/client@deploy-asset/
+  ASSET_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
+# This is for deploy on github pages, as they have a /client/ prefix
+# Example final url: visualizd.github.io/client/
+# Example variable value: client/
+  PUBLIC_PATH: "${{ github.event.repository.name }}/"
+# necessory for asset and deploy branching:
+  ASSET_BRANCH: deploy-asset
 on: 
   workflow_dispatch:
   push:
@@ -11,8 +20,6 @@ jobs:
     name: Build project (prod)
     runs-on: ubuntu-latest
     steps:
-      - name: Setup assest branch variable
-        run: echo ::set-env name=ASSET_BRANCH::deploy-asset
 
       - name: Checkout branch
         uses: actions/checkout@v2
@@ -31,8 +38,6 @@ jobs:
 
       - name: Run npm build script (prod, using jsdelivr)
         run: npm run build:prod
-        env:
-          ASSET_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
       
       - name: Move assets to root folder
         run: mv ./dist/assets ./assets
@@ -54,8 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-production-files]
     steps:
-      - name: Setup assest branch variable
-        run: echo ::set-env name=ASSET_BRANCH::deploy-asset
       
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -42,13 +42,13 @@ jobs:
       - name: Upload assets
         uses: actions/upload-artifact@v2
         with:
-          name: "Assets-$GITHUB_SHA"
+          name: Assets-${{ GITHUB_SHA }}
           path: ./assets
       
       - name: Upload deploy file
         uses: actions/upload-artifact@v2
         with:
-          name: "Deployment-$GITHUB_SHA"
+          name: Deployment-${{ GITHUB_SHA }}
           path: ./dist
           
   commit-assets:
@@ -70,7 +70,7 @@ jobs:
       - name: Download Assests
         uses: actions/download-artifact@v2
         with:
-          name: "Assets-$GITHUB_SHA"
+          name: "Assets-${{ GITHUB_SHA }}"
           path: ./assets
           
       - name: Commit and push assests if necessary
@@ -99,7 +99,7 @@ jobs:
       - name: Download deployment files
         uses: actions/download-artifact@v2
         with:
-          name: "Deployment-$GITHUB_SHA"
+          name: Deployment-${{ GITHUB_SHA }}
           path: ./dep
         
       - name: Add files to git

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -9,6 +9,7 @@ env:
   PUBLIC_PATH: "/${{ github.event.repository.name }}/"
 # necessory for asset and deploy branching:
   ASSET_BRANCH: deploy-asset
+  DEPLOY_BRANCH: gh-pages
 on: 
   workflow_dispatch:
   push:
@@ -63,7 +64,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
-          ref: deploy-asset
+          ref: ${{ ASSET_BRANCH }}
       
       - name: Config git
         run: git config user.name "0w0 Deploy Bot"
@@ -96,7 +97,7 @@ jobs:
         run: git config user.name "0w0 Deploy Bot"
       
       - name: Create orphan github pages branch
-        run: git checkout --orphan gh-pages
+        run: git checkout --orphan ${{ DEPLOY_BRANCH }}
         
       - name: Download deployment files
         uses: actions/download-artifact@v2
@@ -110,4 +111,4 @@ jobs:
       - name: Commit and push deployment if necessary
         run: |
           git commit -m "Compiled deployment for $(git rev-parse --short $GITHUB_SHA) (0w0)"
-          git push origin HEAD:gh-pages --force
+          git push origin HEAD:${{ DEPLOY_BRANCH }} --force

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -6,19 +6,16 @@ name: Deploy github pages
 on: 
   workflow_dispatch:
   push:
+    branches:
+      - master
 
 jobs:
   build-production-files:
-    name: Build assests and files for production
+    name: Build project (prod)
     runs-on: ubuntu-latest
     steps:
       - name: Setup assest branch variable
         run: echo ::set-env name=ASSET_BRANCH::deploy-asset
-
-      - name: Setup Node.js for use with actions
-        uses: actions/setup-node@v1.1.0
-        with:
-          version:  12.x
 
       - name: Checkout branch
         uses: actions/checkout@v2
@@ -26,7 +23,7 @@ jobs:
           submodules: 'recursive'
 
       - name: Install npm dependency
-        run: npm ci
+        uses: bahmutov/npm-install@v1
 
       - name: Run npm build script (prod, using jsdelivr)
         run: npm run build:prod
@@ -39,13 +36,13 @@ jobs:
       - name: Upload assets
         uses: actions/upload-artifact@v2
         with:
-          name: assets
+          name: Assets-$GITHUB_SHA
           path: ./assets
       
       - name: Upload deploy file
         uses: actions/upload-artifact@v2
         with:
-          name: deployment-file
+          name: Deployment-$GITHUB_SHA
           path: ./dist
           
   commit-assets:
@@ -67,7 +64,7 @@ jobs:
       - name: Download Assests
         uses: actions/download-artifact@v2
         with:
-          name: assets
+          name: Assets-$GITHUB_SHA
           path: ./assets
           
       - name: Commit and push assests if necessary
@@ -96,7 +93,7 @@ jobs:
       - name: Download deployment files
         uses: actions/download-artifact@v2
         with:
-          name: deployment-file
+          name: Deployment-$GITHUB_SHA
           path: ./dep
         
       - name: Add files to git

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
-          ref: ${{ ASSET_BRANCH }}
+          ref: $ASSET_BRANCH
       
       - name: Config git
         run: git config user.name "0w0 Deploy Bot"
@@ -80,7 +80,7 @@ jobs:
          if [ -n "$(git status --porcelain)" ]; then
             git add ./assets
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (0w0)"
-            git push origin HEAD:${ASSET_BRANCH} --force
+            git push origin HEAD:$ASSET_BRANCH --force
          else
            echo "No need to commit as there's no changes"
          fi
@@ -97,7 +97,7 @@ jobs:
         run: git config user.name "0w0 Deploy Bot"
       
       - name: Create orphan github pages branch
-        run: git checkout --orphan ${{ DEPLOY_BRANCH }}
+        run: git checkout --orphan $DEPLOY_BRANCH
         
       - name: Download deployment files
         uses: actions/download-artifact@v2
@@ -111,4 +111,4 @@ jobs:
       - name: Commit and push deployment if necessary
         run: |
           git commit -m "Compiled deployment for $(git rev-parse --short $GITHUB_SHA) (0w0)"
-          git push origin HEAD:${{ DEPLOY_BRANCH }} --force
+          git push origin HEAD:$DEPLOY_BRANCH --force

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -82,12 +82,12 @@ jobs:
           
       - name: Commit and push assests if necessary
         run: |
-         # if [[ $(git status --short ./assests) != '' ]]; then
+         if [ -n "$(git status --porcelain)" ]; then
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (0w0)"
             git push origin HEAD:${ASSET_BRANCH} --force
-         # else
-         #   echo "No need to commit as there's no changes"
-         # fi
+         else
+           echo "No need to commit as there's no changes"
+         fi
 
   deploy-github-page:
     name: Deploy to github pages branch

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -1,13 +1,10 @@
 name: Deploy github pages
-#on:
-#    push:
-#      branches:
-#        - master
+
 on: 
   workflow_dispatch:
   push:
-    branches:
-      - master
+#     branches:
+#       - master
 
 jobs:
   build-production-files:

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -60,7 +60,7 @@ jobs:
           ref: deploy-asset
       
       - name: Config git
-        run: git config user.name "Assest Bot"
+        run: git config user.name "0w0 Deploy Bot"
       
       - name: Download Assests
         uses: actions/download-artifact@v2
@@ -77,7 +77,7 @@ jobs:
       - name: Commit and push assests if necessary
         run: |
           if [[ $(git diff --stat) != '' ]]; then
-            git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (uwu)"
+            git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (0w0)"
             git push origin HEAD:${ASSET_BRANCH} --force
           else
             echo "No need to commit as there's no changes"
@@ -91,6 +91,9 @@ jobs:
       
       - name: Checkout Repo
         uses: actions/checkout@v2
+      
+      - name: Config git
+        run: git config user.name "0w0 Deploy Bot"
       
       - name: Create orphan github pages branch
         run: git checkout --orphan gh-pages

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -76,8 +76,8 @@ jobs:
       
       - name: Config git
         run: |
-          git config user.name $GIT_BOT_NAME
-          git config user.email $GIT_BOT_EMAIL
+          git config user.name ${{ env.GIT_BOT_NAME }}
+          git config user.email ${{ env.GIT_BOT_EMAIL }}
       
       - name: Download Assests
         uses: actions/download-artifact@v2
@@ -105,8 +105,8 @@ jobs:
       
       - name: Config git
         run: |
-          git config user.name $GIT_BOT_NAME
-          git config user.email $GIT_BOT_EMAIL
+          git config user.name ${{ env.GIT_BOT_NAME }}
+          git config user.email ${{ env.GIT_BOT_EMAIL }}
       
       - name: Create orphan github pages branch
         run: git checkout --orphan $DEPLOY_BRANCH

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -71,8 +71,14 @@ jobs:
       - name: List directory (for debugging)
         run: ls -R
         
+      - name: git status before tracking (for debugging)
+        run: git status --short ./assests
+        
       - name:  Add assests to git
         run: git add ./assets
+        
+      - name: git status after tracking (for debugging)
+        run: git status --short ./assests
           
       - name: Commit and push assests if necessary
         run: |

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -1,6 +1,11 @@
 name: Deploy github pages
 
-env: 
+env:
+# --------------Runtime config------------------------------------------------------------
+#  Vue.js router's mode, set to hash as github pages
+#  do not support "any" path matching yet
+  ROUTER_MODE: hash
+
 # --------------Necessory for asset and deploy branching:---------------------------------
 # The branch where assets are deploying to
   ASSET_BRANCH: deploy-asset

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup assest branch variable
-        run: "::set-env name=ASSET_BRANCH::deploy-asset"
+        run: "echo ::set-env name=ASSET_BRANCH::deploy-asset"
 
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v1.1.0

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -42,13 +42,13 @@ jobs:
       - name: Upload assets
         uses: actions/upload-artifact@v2
         with:
-          name: Assets-${{ GITHUB_SHA }}
+          name: Assets-${{ env.GITHUB_SHA }}
           path: ./assets
       
       - name: Upload deploy file
         uses: actions/upload-artifact@v2
         with:
-          name: Deployment-${{ GITHUB_SHA }}
+          name: Deployment-${{ env.GITHUB_SHA }}
           path: ./dist
           
   commit-assets:
@@ -70,7 +70,7 @@ jobs:
       - name: Download Assests
         uses: actions/download-artifact@v2
         with:
-          name: "Assets-${{ GITHUB_SHA }}"
+          name: "Assets-${{ env.GITHUB_SHA }}"
           path: ./assets
           
       - name: Commit and push assests if necessary
@@ -99,7 +99,7 @@ jobs:
       - name: Download deployment files
         uses: actions/download-artifact@v2
         with:
-          name: Deployment-${{ GITHUB_SHA }}
+          name: Deployment-${{ env.GITHUB_SHA }}
           path: ./dep
         
       - name: Add files to git

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -1,7 +1,13 @@
 name: Deploy github pages
 
 env: 
-# Necessary for building production code
+# --------------Necessory for asset and deploy branching:---------------------------------
+# The branch where assets are deploying to
+  ASSET_BRANCH: deploy-asset
+# The branch where production files (ex: index.html) are deploying to
+  DEPLOY_BRANCH: gh-pages
+
+# --------------Necessary for building production code------------------------------------
 # Example: https://cdn.jsdelivr.net/gh/visualizd/client@deploy-asset/
   ASSET_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
 
@@ -9,14 +15,10 @@ env:
 # Example final url: visualizd.github.io/client/
 # Example variable value: /client/
   PUBLIC_PATH: "/${{ github.event.repository.name }}/"
-# necessory for asset and deploy branching:
-  ASSET_BRANCH: deploy-asset
-  DEPLOY_BRANCH: gh-pages
 
-# Git bot name
-  GIT_BOT_NAME: '"0w0 Deploy Bot"'
-# Blank ""
-  GIT_BOT_EMAIL: '""'
+# --------------Git bot setup-------------------------------------------------------------
+  GIT_BOT_NAME: '"0w0 Deploy Bot"' # double quote must be reserved
+  GIT_BOT_EMAIL: '""' # left blank intentionally 
   
 on: 
   workflow_dispatch:

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
         with:
-          ref: $ASSET_BRANCH
+          ref: ${{ env.ASSET_BRANCH }}
       
       - name: Config git
         run: git config user.name "0w0 Deploy Bot"

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -5,8 +5,8 @@ env:
   ASSET_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
 # This is for deploy on github pages, as they have a /client/ prefix
 # Example final url: visualizd.github.io/client/
-# Example variable value: client/
-  PUBLIC_PATH: "${{ github.event.repository.name }}/"
+# Example variable value: /client/
+  PUBLIC_PATH: "/${{ github.event.repository.name }}/"
 # necessory for asset and deploy branching:
   ASSET_BRANCH: deploy-asset
 on: 

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup assest branch variable
-          - run: "::set-env name=ASSET_BRANCH::deploy-asset"
+        run: "::set-env name=ASSET_BRANCH::deploy-asset"
 
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v1.1.0

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -68,8 +68,10 @@ jobs:
           name: assets
           path: ./assets
         
-      - name: Display directory structure (for debuging)
-        run: ls -R
+      - name: Debuging output
+        run: |
+          git diff --stat
+          ls -R
         
       - name:  Add assests to git
         run: git add ./assets

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -67,6 +67,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: assets
+          path: ./assets
+        
+      - name: Display directory structure (for debuging)
+        run: ls -R
           
       - name: Add assests to git
         run: git --work-tree assets add --all

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -42,13 +42,13 @@ jobs:
       - name: Upload assets
         uses: actions/upload-artifact@v2
         with:
-          name: Assets-${{ env.GITHUB_SHA }}
+          name: Assets-${{ github.sha }}
           path: ./assets
       
       - name: Upload deploy file
         uses: actions/upload-artifact@v2
         with:
-          name: Deployment-${{ env.GITHUB_SHA }}
+          name: Deployment-${{ github.sha }}
           path: ./dist
           
   commit-assets:
@@ -70,7 +70,7 @@ jobs:
       - name: Download Assests
         uses: actions/download-artifact@v2
         with:
-          name: "Assets-${{ env.GITHUB_SHA }}"
+          name: "Assets-${{ github.sha }}"
           path: ./assets
           
       - name: Commit and push assests if necessary
@@ -99,7 +99,7 @@ jobs:
       - name: Download deployment files
         uses: actions/download-artifact@v2
         with:
-          name: Deployment-${{ env.GITHUB_SHA }}
+          name: Deployment-${{ github.sha }}
           path: ./dep
         
       - name: Add files to git

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -32,13 +32,13 @@ jobs:
           PUBLIC_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
       
       - name: Move assets to root folder
-        run: mv ./dist/asset ./asset
+        run: mv ./dist/assets ./assets
       
       - name: Upload assets
         uses: actions/upload-artifact@v2
         with:
           name: assets
-          path: ./asset
+          path: ./assets
       
       - name: Upload deploy file
         uses: actions/upload-artifact@v2

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -14,7 +14,7 @@ env:
   DEPLOY_BRANCH: gh-pages
 
 # Git bot name
-  GIT_BOT_NAME: \"0w0 Deploy Bot\"
+  GIT_BOT_NAME: "0w0 Deploy Bot"
 # See: https://github.community/t/github-actions-bot-email-address/17204/5
   GIT_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
   

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -66,7 +66,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: assets
-          path: .
+          path: ./assets
         
       - name: Display directory structure (for debuging)
         run: ls -R

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -15,7 +15,7 @@ env:
 
 # Git bot name
   GIT_BOT_NAME: '"0w0 Deploy Bot"'
-  GIT_BOT_EMAIL: action@github.com
+  GIT_BOT_EMAIL: ""
   
 on: 
   workflow_dispatch:

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -6,12 +6,12 @@ name: Deploy github pages
 on: [workflow_dispatch, push]
 
 jobs:
-  gh-pages-deploy:
+  build-production-files:
     name: Deploy to gh-pages
     runs-on: ubuntu-latest
     steps:
       - name: Setup assest branch variable
-        run: "echo ::set-env name=ASSET_BRANCH::deploy-asset"
+        run: echo ::set-env name=ASSET_BRANCH::deploy-asset
 
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v1.1.0
@@ -30,5 +30,20 @@ jobs:
         run: npm run build:prod
         env:
           PUBLIC_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
+      
+      - name: Move assets to root folder
+        run: mv ./dist/asset ./asset
+      
+      - name: Upload assets
+        uses: actions/upload-artifact@v2
+        with:
+          name: assets
+          path: ./asset
+      
+      - name: Upload deploy file
+        uses: actions/upload-artifact@v2
+        with:
+          name: deploy
+          path: ./dist
 
-      # TODO: Copying asset, push to asset branch & github-pages branch
+      # TODO: Deploy asset and deploy files to github pages and jsdelivr branch

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -68,17 +68,15 @@ jobs:
           name: assets
           path: ./assets
         
-      - name: Debuging output
-        run: |
-          git diff --stat
-          ls -R
+      - name: List directory (for debugging)
+        run: ls -R
         
       - name:  Add assests to git
         run: git add ./assets
           
       - name: Commit and push assests if necessary
         run: |
-          if [[ $(git diff --stat) != '' ]]; then
+          if [[ $(git status --short ./assests) != '' ]]; then
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (0w0)"
             git push origin HEAD:${ASSET_BRANCH} --force
           else
@@ -111,7 +109,7 @@ jobs:
         
       - name: Commit and push deployment if necessary
         run: |
-          if [[ $(git diff --stat) != '' ]]; then
+          if [[ $(git status --short) != '' ]]; then
             git commit -m "Compiled deployment for $(git rev-parse --short $GITHUB_SHA) (0w0)"
             git push origin HEAD:gh-pages --force
           else

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -70,14 +70,16 @@ jobs:
         
       - name: Display directory structure (for debuging)
         run: ls -R
-          
-      - name: Add assests to git
+        
+      - name:  Add assests to git
         run: git add --all
-      
-      - name: Commit Assests
+          
+      - name: Commit and push assests if necessary
         run: |
-          git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (uwu)"
-          
-      - name: Push to Github
-        run: git push origin HEAD:${ASSET_BRANCH} --force
-          
+          if [ $(git diff --stat) != '' ] then
+            git add --all
+            git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (uwu)"
+            git push origin HEAD:${ASSET_BRANCH} --force
+          else
+            echo "No need to commit as there's no changes"
+          fi

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -76,7 +76,7 @@ jobs:
           
       - name: Commit and push assests if necessary
         run: |
-          if [ $(git diff --stat) != '' ]; then
+          if [[ $(git diff --stat) != '' ]]; then
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (uwu)"
             git push origin HEAD:${ASSET_BRANCH} --force
           else
@@ -106,7 +106,7 @@ jobs:
         
       - name: Commit and push deployment if necessary
         run: |
-          if [ $(git diff --stat) != '' ]; then
+          if [[ $(git diff --stat) != '' ]]; then
             git commit -m "Compiled deployment for $(git rev-parse --short $GITHUB_SHA) (0w0)"
             git push origin HEAD:gh-pages --force
           else

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -82,12 +82,12 @@ jobs:
           
       - name: Commit and push assests if necessary
         run: |
-          if [[ $(git status --short ./assests) != '' ]]; then
+         # if [[ $(git status --short ./assests) != '' ]]; then
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (0w0)"
             git push origin HEAD:${ASSET_BRANCH} --force
-          else
-            echo "No need to commit as there's no changes"
-          fi
+         # else
+         #   echo "No need to commit as there's no changes"
+         # fi
 
   deploy-github-page:
     name: Deploy to github pages branch

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Commit and push assests if necessary
         run: |
          if [ -n "$(git status --porcelain)" ]; then
+            git add ./assets
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (0w0)"
             git push origin HEAD:${ASSET_BRANCH} --force
          else

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -3,11 +3,13 @@ name: Deploy github pages
 #    push:
 #      branches:
 #        - master
-on: [workflow_dispatch, push]
+on: 
+  workflow_dispatch:
+  push:
 
 jobs:
   build-production-files:
-    name: Deploy to gh-pages
+    name: Build assests and files for production
     runs-on: ubuntu-latest
     steps:
       - name: Setup assest branch variable
@@ -67,18 +69,6 @@ jobs:
         with:
           name: assets
           path: ./assets
-        
-      - name: List directory (for debugging)
-        run: ls -R
-        
-      - name: git status before tracking (for debugging)
-        run: git status --short ./assests
-        
-      - name:  Add assests to git
-        run: git add ./assets
-        
-      - name: git status after tracking (for debugging)
-        run: git status --short ./assests
           
       - name: Commit and push assests if necessary
         run: |
@@ -94,7 +84,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-production-files, commit-assets]
     steps:
-      
       - name: Checkout Repo
         uses: actions/checkout@v2
       
@@ -115,9 +104,5 @@ jobs:
         
       - name: Commit and push deployment if necessary
         run: |
-          if [[ $(git status --short) != '' ]]; then
-            git commit -m "Compiled deployment for $(git rev-parse --short $GITHUB_SHA) (0w0)"
-            git push origin HEAD:gh-pages --force
-          else
-            echo "No need to commit as there's no changes"
-          fi
+          git commit -m "Compiled deployment for $(git rev-parse --short $GITHUB_SHA) (0w0)"
+          git push origin HEAD:gh-pages --force

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -72,7 +72,7 @@ jobs:
         run: ls -R
         
       - name:  Add assests to git
-        run: git add --all
+        run: git add ./assets
           
       - name: Commit and push assests if necessary
         run: |

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -1,8 +1,10 @@
 name: Deploy github pages
+
 env: 
-# necessary for building production code
+# Necessary for building production code
 # Example: https://cdn.jsdelivr.net/gh/visualizd/client@deploy-asset/
   ASSET_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
+
 # This is for deploy on github pages, as they have a /client/ prefix
 # Example final url: visualizd.github.io/client/
 # Example variable value: /client/
@@ -10,6 +12,12 @@ env:
 # necessory for asset and deploy branching:
   ASSET_BRANCH: deploy-asset
   DEPLOY_BRANCH: gh-pages
+
+# Git bot name
+  GIT_BOT_NAME: 0w0 Deploy Bot
+# See: https://github.community/t/github-actions-bot-email-address/17204/5
+  GIT_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+  
 on: 
   workflow_dispatch:
   push:
@@ -67,7 +75,9 @@ jobs:
           ref: ${{ env.ASSET_BRANCH }}
       
       - name: Config git
-        run: git config user.name "0w0 Deploy Bot"
+        run: |
+          git config user.name $GIT_BOT_NAME
+          git config user.email $GIT_BOT_EMAIL
       
       - name: Download Assests
         uses: actions/download-artifact@v2
@@ -94,7 +104,9 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Config git
-        run: git config user.name "0w0 Deploy Bot"
+        run: |
+          git config user.name $GIT_BOT_NAME
+          git config user.email $GIT_BOT_EMAIL
       
       - name: Create orphan github pages branch
         run: git checkout --orphan $DEPLOY_BRANCH

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -21,8 +21,8 @@ env:
 on: 
   workflow_dispatch:
   push:
-#     branches:
-#       - master
+    branches:
+      - master
 
 jobs:
   build-production-files:

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -76,7 +76,7 @@ jobs:
           
       - name: Commit and push assests if necessary
         run: |
-          if [ $(git diff --stat) != '' ] then
+          if [ $(git diff --stat) != '' ]; then
             git add --all
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (uwu)"
             git push origin HEAD:${ASSET_BRANCH} --force

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -33,13 +33,13 @@ jobs:
       - name: Upload assets
         uses: actions/upload-artifact@v2
         with:
-          name: Assets-$GITHUB_SHA
+          name: "Assets-$GITHUB_SHA"
           path: ./assets
       
       - name: Upload deploy file
         uses: actions/upload-artifact@v2
         with:
-          name: Deployment-$GITHUB_SHA
+          name: "Deployment-$GITHUB_SHA"
           path: ./dist
           
   commit-assets:
@@ -61,7 +61,7 @@ jobs:
       - name: Download Assests
         uses: actions/download-artifact@v2
         with:
-          name: Assets-$GITHUB_SHA
+          name: "Assets-$GITHUB_SHA"
           path: ./assets
           
       - name: Commit and push assests if necessary
@@ -90,7 +90,7 @@ jobs:
       - name: Download deployment files
         uses: actions/download-artifact@v2
         with:
-          name: Deployment-$GITHUB_SHA
+          name: "Deployment-$GITHUB_SHA"
           path: ./dep
         
       - name: Add files to git

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -15,6 +15,7 @@ env:
 
 # Git bot name
   GIT_BOT_NAME: '"0w0 Deploy Bot"'
+# Blank ""
   GIT_BOT_EMAIL: '""'
   
 on: 
@@ -87,7 +88,7 @@ jobs:
       - name: Commit and push assests if necessary
         run: |
          if [ -n "$(git status --porcelain)" ]; then
-            git add ./assets
+            git add assets
             git commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) (0w0)"
             git push origin HEAD:$ASSET_BRANCH --force
          else
@@ -119,7 +120,7 @@ jobs:
       - name: Add files to git
         run: git --work-tree dep add --all
         
-      - name: Commit and push deployment if necessary
+      - name: Commit and push deployment files to ${{ env.DEPLOY_BRANCH }}
         run: |
           git commit -m "Compiled deployment for $(git rev-parse --short $GITHUB_SHA) (0w0)"
           git push origin HEAD:$DEPLOY_BRANCH --force

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -15,7 +15,7 @@ env:
 
 # Git bot name
   GIT_BOT_NAME: '"0w0 Deploy Bot"'
-  GIT_BOT_EMAIL: ""
+  GIT_BOT_EMAIL: '""'
   
 on: 
   workflow_dispatch:

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -21,6 +21,15 @@ jobs:
 
       - name: Install npm dependency
         uses: bahmutov/npm-install@v1
+        
+      - name: Load build cache
+        uses: actions/cache@v2
+        with:
+          path: ./node_modules/.cache
+          # anything should help
+          # if it causes trouble,
+          # just increment the trailling number
+          key: build-cache-0 
 
       - name: Run npm build script (prod, using jsdelivr)
         run: npm run build:prod

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run npm build script (prod, using jsdelivr)
         run: npm run build:prod
         env:
-          PUBLIC_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
+          ASSET_PATH: "https://cdn.jsdelivr.net/gh/${{ github.repository }}@$ASSET_BRANCH/"
       
       - name: Move assets to root folder
         run: mv ./dist/assets ./assets

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -67,10 +67,12 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: assets
+          
+      - name: Add assests to git
+        run: git --work-tree assets add --all
       
       - name: Commit Assests
         run: |
-          git --work-tree assets add --all
           git --work-tree assets commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) uwu"
           
       - name: Push to Github

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -15,8 +15,7 @@ env:
 
 # Git bot name
   GIT_BOT_NAME: '"0w0 Deploy Bot"'
-# See: https://github.community/t/github-actions-bot-email-address/17204/5
-  GIT_BOT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+  GIT_BOT_EMAIL: action@github.com
   
 on: 
   workflow_dispatch:

--- a/.github/workflows/deploy_github_page.yml
+++ b/.github/workflows/deploy_github_page.yml
@@ -43,7 +43,36 @@ jobs:
       - name: Upload deploy file
         uses: actions/upload-artifact@v2
         with:
-          name: deploy
+          name: deployment-file
           path: ./dist
-
-      # TODO: Deploy asset and deploy files to github pages and jsdelivr branch
+          
+  commit-assets:
+    name: Commit Assets
+    runs-on: ubuntu-latest
+    needs: [build-production-files]
+    steps:
+      - name: Setup assest branch variable
+        run: echo ::set-env name=ASSET_BRANCH::deploy-asset
+      
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      
+      - name: Config git
+        run: git config user.name "Assest Bot"
+        
+      - name: Switch Branch
+        run: git checkout --orphan $ASSET_BRANCH
+      
+      - name: Download Assests
+        uses: actions/download-artifact@v2
+        with:
+          name: assets
+      
+      - name: Commit Assests
+        run: |
+          git --work-tree assets add --all
+          git --work-tree assets commit -m "Compiled deployment assest for $(git rev-parse --short $GITHUB_SHA) uwu"
+          
+      - name: Push to Github
+        run: git push origin HEAD:${ASSET_BRANCH} --force
+      

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",
-    "build": "vue-cli-service build",
+    "build": "vue-cli-service build --mode development",
+    "build:prod": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,7 +8,7 @@ import Projects from '../components/Projects.vue';
 
 Vue.use(VueRouter)
 
-  const routes: Array<RouteConfig> = [
+const routes: Array<RouteConfig> = [
   {
     path: '/',
     name: 'Main',
@@ -40,7 +40,7 @@ Vue.use(VueRouter)
 ]
 
 const router = new VueRouter({
-  mode: 'history',
+  mode: process.env.ROUTER_MODE,
   base: process.env.BASE_URL,
   routes
 })

--- a/vue.config.js
+++ b/vue.config.js
@@ -13,9 +13,11 @@ const getDevConfig = () => {
 }
 
 const getProductionConfig = () => {
+  const publicPath = process.env["PUBLIC_PATH"];
+  console.log(`Compiling with public path: ${publicPath}`);
   return {
     integrity: true,
-    publicPath: process.env["PUBLIC_PATH"],
+    publicPath: publicPath,
     crossorigin: "anonymous"
   }
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,7 +1,23 @@
-module.exports = {
-  devServer: {
-    allowedHosts: [
-      '.ws-us02.gitpod.io'
-    ]
+const getDevConfig = () => {
+  return {
+    devServer: {
+      allowedHosts: [
+        '.ws-us02.gitpod.io'
+      ]
+    }
   }
+}
+
+const getProductionConfig = () => {
+  return {
+    integrity: true,
+    publicPath: process.env["PUBLIC_PATH"],
+    crossorigin: "anonymous"
+  }
+}
+
+if (process.env.NODE_ENV === "production") {
+  module.exports = getProductionConfig();
+} else {
+  module.exports = getDevConfig();
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -13,13 +13,37 @@ const getDevConfig = () => {
 }
 
 const getProductionConfig = () => {
-  const publicPath = process.env["PUBLIC_PATH"];
-  console.log(`Compiling with public path: ${publicPath}`);
-  return {
-    integrity: true,
-    publicPath: publicPath,
-    crossorigin: "anonymous"
-  }
+  const assetPath = process.env["ASSET_PATH"];
+  const deployPublicPath = process.env["PUBLIC_PATH"];
+  console.log(`Compiling with asset path: ${assetPath}, public path: ${deployPublicPath}`);
+
+  // files referenced in HTML template, is placed under the /public folder
+  // all files inside this folder will be copied over to deploy public path
+
+  // this piece of code overrides the BASE_URL template in the index.html template
+  // so that files referenced in the HTML template but not processed in the webpack system
+  // will have a correct reference url
+  const overrideBaseURLTemplate = {
+    chainWebpack: config => {
+      config.plugin("html").tap(args => {
+        const original = args[0].templateParameters;
+        args[0].templateParameters = (compilation, assets, pluginOptions) => {
+          return Object.assign(original(compilation, assets, pluginOptions), {
+            BASE_URL: deployPublicPath
+          })
+        }
+        return args;
+      })
+    }
+  };
+
+  return Object.assign({
+        integrity: true,
+        publicPath: assetPath,
+        crossorigin: "anonymous",
+      },
+      overrideBaseURLTemplate
+  )
 }
 
 if (process.env.NODE_ENV === "production") {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,7 @@
+const baseConfig = {
+  assetsDir: "assets",
+}
+
 const getDevConfig = () => {
   return {
     devServer: {
@@ -17,7 +21,7 @@ const getProductionConfig = () => {
 }
 
 if (process.env.NODE_ENV === "production") {
-  module.exports = getProductionConfig();
+  module.exports = Object.assign({}, baseConfig, getProductionConfig());
 } else {
-  module.exports = getDevConfig();
+  module.exports = Object.assign({}, baseConfig, getDevConfig());
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,14 @@
 const baseConfig = {
   assetsDir: "assets",
+  chainWebpack: webpackConfig => {
+    webpackConfig.plugin("define").tap(defineConfig => {
+      const runtimeEnv = defineConfig[0]["process.env"];
+      const routerMode = JSON.stringify(process.env["ROUTER_MODE"] || "history");
+      runtimeEnv["ROUTER_MODE"] = routerMode;
+      console.log(`using router mode: ${routerMode}`);
+      return defineConfig;
+    })
+  }
 }
 
 const getDevConfig = () => {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,13 +1,19 @@
+// inject ROUTER_MODE from build environment variable to runtime
+// see: https://github.com/wusatosi/client/blob/1b15c03d4f50d59fbeec6e8397b68d40320e5b1b/.env#L23-L29
+function injectRouterModeEnvToRuntime(webpackConfig) {
+  webpackConfig.plugin("define").tap(defineConfig => {
+    const runtimeEnv = defineConfig[0]["process.env"];
+    const routerMode = JSON.stringify(process.env["ROUTER_MODE"] || "history");
+    runtimeEnv["ROUTER_MODE"] = routerMode;
+    console.log(`using router mode: ${routerMode}`);
+    return defineConfig;
+  })
+}
+
 const baseConfig = {
   assetsDir: "assets",
   chainWebpack: webpackConfig => {
-    webpackConfig.plugin("define").tap(defineConfig => {
-      const runtimeEnv = defineConfig[0]["process.env"];
-      const routerMode = JSON.stringify(process.env["ROUTER_MODE"] || "history");
-      runtimeEnv["ROUTER_MODE"] = routerMode;
-      console.log(`using router mode: ${routerMode}`);
-      return defineConfig;
-    })
+    injectRouterModeEnvToRuntime(webpackConfig);
   }
 }
 
@@ -22,33 +28,46 @@ const getDevConfig = () => {
 }
 
 const getProductionConfig = () => {
+  // this is where assets will be deployed, normally on jsdelivr's cdn
   const assetPath = process.env["ASSET_PATH"];
+  // this is the main domain our site is hosted on, for example visualizd.github.io
   const deployPublicPath = process.env["PUBLIC_PATH"];
   console.log(`Compiling with asset path: ${assetPath}, public path: ${deployPublicPath}`);
 
-  // files referenced in HTML template, is placed under the /public folder
-  // all files inside this folder will be copied over to deploy public path
-
-  // this piece of code overrides the BASE_URL template in the index.html template
+  // Files referenced directly in HTML template should be placed under the /public folder
+  // all files inside the /public/ directory will be copied over to deploy public path,
+  // on the same domain and prefix as index.html.
+  //          (ex: visualizd.github.io/client/ instead of cdn.jsdelivr.net)
+  // This following piece of code overrides the BASE_URL template in the index.html template
   // so that files referenced in the HTML template but not processed in the webpack system
   // will have a correct reference url
   const overrideBaseURLTemplate = {
     chainWebpack: config => {
       config.plugin("html").tap(args => {
+        // vue-cli has this config set to a special function,
+        // to make sure build will work, this function is
+        // reserved
         const original = args[0].templateParameters;
-        args[0].templateParameters = (compilation, assets, pluginOptions) => {
-          return Object.assign(original(compilation, assets, pluginOptions), {
-            BASE_URL: deployPublicPath
-          })
-        }
+        args[0].templateParameters = (compilation, assets, pluginOptions) => Object.assign(
+            // ensure the original function is reserved
+            original(compilation, assets, pluginOptions),
+            // overrides the base url to that of the deployment path instead of asset path
+            {
+              BASE_URL: deployPublicPath
+            }
+        )
         return args;
       })
     }
   };
 
   return Object.assign({
+    // enable sub-resource integrity check as our executables are deployed on other's infra
+    // there were records where jsdelivr was poisoned
+    // see: https://github.com/jsdelivr/jsdelivr/issues/18049
         integrity: true,
         publicPath: assetPath,
+    // necessary for assests hosted by jsdelivr cdn to work as it counts as cors
         crossorigin: "anonymous",
       },
       overrideBaseURLTemplate
@@ -56,7 +75,7 @@ const getProductionConfig = () => {
 }
 
 if (process.env.NODE_ENV === "production") {
-  module.exports = Object.assign({}, baseConfig, getProductionConfig());
+  module.exports = Object.assign(baseConfig, getProductionConfig());
 } else {
-  module.exports = Object.assign({}, baseConfig, getDevConfig());
+  module.exports = Object.assign(baseConfig, getDevConfig());
 }


### PR DESCRIPTION
What this does:
On every push to the master branch, a GitHub action is triggered. It:

1.  Config build option to export files with base path of jsdelivr's cdn url
2.  Builds the project using `npm run build:prod` 
3.  Separate the assets and deployment file (assets are identified by their presence in `dist/assets` folder) from the `dist` folder
4.  Push the assets to the `deploy-asset` branch's `assets` folder, this provides a way for jsdelivr to fetch the files without using Tags or commit hash
5.  Push the deployment file to the `gp-page` branch so GitHub pages works correctly

Does it work right now:
_Some what_, but not ready

Known issue:
- [x] Incorrect Favicon reference in index.html. (This will be explained later)

Before merge:
- [x] Uncomment activation branch restriction to master section (Brad will handle this)